### PR TITLE
Parallelization of Inform and adding option to use sklearn's decision trees (covers #7 and #11)

### DIFF
--- a/.github/workflows/testing-and-coverage.yml
+++ b/.github/workflows/testing-and-coverage.yml
@@ -23,6 +23,10 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+    - name: setup mpi
+      uses: mpi4py/setup-mpi@v1
+      with:
+        mpi: openmpi
     - name: Install dependencies
       run: |
         sudo apt-get update

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "pandas",
     "pz-rail-base",
     "qp-prob[full]",
+    "scikit-learn",
 ]
 
 # On a mac, install optional dependencies with `pip install '.[dev]'` (include the single quotes)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dynamic = ["version"]
 
 dependencies = [
     "astropy",
+    "mpi4py",
     "pandas",
     "pz-rail-base",
     "qp-prob[full]",

--- a/src/rail/estimation/algos/mlz_utils/utils_mlz.py
+++ b/src/rail/estimation/algos/mlz_utils/utils_mlz.py
@@ -152,3 +152,24 @@ def compute_zConf2(z, pdf, zv, sigma):
     ib1 = np.argmin(abs(z1a - z))
     ib2 = np.argmin(abs(z1b - z)) + 1
     return sum(pdf[ib1:ib2])
+
+
+def get_limits(ntot, Nproc, rank):
+    """
+    Get limits for farming an array to multiple processors
+
+    :param int ntot: Number of objects in array
+    :param int Nproc: number of processor
+    :param int rank: current processor id
+    :return: L1,L2 the limits of the array for given processor
+    :rtype: int, int
+    """
+    jpproc = np.zeros(Nproc) + int(ntot / Nproc)
+    for i in range(Nproc):
+        if (i < ntot % Nproc): jpproc[i] += 1
+    jpproc = [int(x) for x in jpproc]
+    st = rank
+    st = np.sum(jpproc[:rank]) - 1
+    s0 = int(st + 1)
+    s1 = int(st + jpproc[rank]) + 1
+    return s0, s1

--- a/src/rail/estimation/algos/tpz_lite.py
+++ b/src/rail/estimation/algos/tpz_lite.py
@@ -132,7 +132,7 @@ class TPZliteInformer(CatInformer):
                           natt=Param(int, 3, msg="number of attributes to split for TPZ"),
                           sigmafactor=Param(float, 3.0, msg="Gaussian smoothing with kernel Sigma1*Resolution"),
                           rmsfactor=Param(float, 0.02, msg="RMS for zconf calculation"),
-                          tree_strategey=Param(str, "native", msg="which decision tree function to use when constructing the forest, \
+                          tree_strategy=Param(str, "native", msg="which decision tree function to use when constructing the forest, \
                                               valid choices are 'native' or 'sklearn'.  If 'native', use the trees written for TPZ,\
                                               if 'sklearn' then use sklearn's DecisionTreeRegressor")
                           )

--- a/src/rail/estimation/algos/tpz_lite.py
+++ b/src/rail/estimation/algos/tpz_lite.py
@@ -26,21 +26,29 @@ from .mlz_utils import utils_mlz
 from .mlz_utils import analysis
 from .ml_codes import TPZ
 
-try:
-    from mpi4py import MPI
+# value copied from ceci/ceci/stage.py, it is set there but not carried around
+MPI_PARALLEL = "mpi"
 
-    PLL = 'MPI'
-except ImportError:  # pragma: no cover
-    PLL = 'SERIAL'
 
-if PLL == 'MPI':
-    comm = MPI.COMM_WORLD
-    size = comm.Get_size()
-    rank = comm.Get_rank()
-else:  # pragma: no cover
-    size = 1
-    rank = 0
-Nproc = size
+# this is handled internally by ceci's stage.py in PipelineStage
+# replace rank with self._rank, size with self._size, comm with self._comm
+# and PLL == 'MPI'  with self._parallel == 'mpi'
+#try:
+#    from mpi4py import MPI
+#
+#    PLL = 'MPI'
+#except ImportError:  # pragma: no cover
+#    PLL = 'SERIAL'
+#
+#if PLL == 'MPI':
+#    comm = MPI.COMM_WORLD
+#    size = comm.Get_size()
+#    rank = comm.Get_rank()
+#else:  # pragma: no cover
+#    size = 1
+#    rank = 0
+#Nproc = size
+
 
 bands = ['u', 'g', 'r', 'i', 'z', 'y']
 def_train_atts = []
@@ -140,21 +148,36 @@ class TPZliteInformer(CatInformer):
         """compute the best fit prior parameters
         """
         rng = np.random.default_rng(seed=self.config.seed)
-        comm.Barrier()
-        if rank == 0:
-            print(f"PLL IS {PLL}, number of processors we will use is {size}")
+        self._comm.Barrier()
+        if self._rank == 0:
+            print(f"self._parallel is {self._parallel}, number of processors we will use is {self._size}")
 
         if self.config.hdf5_groupname:
             training_data = self.get_data("input")[self.config.hdf5_groupname]
         else:  # pragma: no cover
             training_data = self.get_data("input")
 
+        # replace non-detects with limiting mag and mag_err with 1.0
+        for bandname, errname in self.config.err_dict.items():
+            if bandname == self.config.redshift_col:
+                continue
+            if np.isnan(self.config.nondetect_val):  # pragma: no cover
+                magmask = np.isnan(training_data[bandname])
+                errmask = np.isnan(training_data[errname])
+            else:
+                magmask = np.isclose(training_data[bandname], self.config.nondetect_val)
+                errmask = np.isclose(training_data[errname], self.config.nondetect_val)
+
+            detmask = np.logical_or(magmask, errmask)
+            training_data[bandname][detmask] = self.config.mag_limits[bandname]
+            training_data[errname][detmask] = 1.0
+
         valid_strategies = ["sklearn", "native"]
         if self.config.tree_strategy not in valid_strategies:  # pragma: no cover
             raise ValueError(f"value of {self.config.tree_strategy} not valid! Valid values for tree_strategy are 'native' or 'sklearn'")
-        if self.config.tree_strategy == "sklearn" and rank == 0:
+        if self.config.tree_strategy == "sklearn" and self._rank == 0:
             print("using sklearn decision trees")
-        if self.config.tree_strategy == "native" and rank == 0:
+        if self.config.tree_strategy == "native" and self._rank == 0:
             print("using native TPZ decision trees")
 
         # TPZ expects a param called `keyatt` that is just the redshift column, copy redshift_col
@@ -183,30 +206,34 @@ class TPZliteInformer(CatInformer):
         # it saves `nrandom` copies of this in a dictionary for each attribute for each galaxy
         # not how I would have done things, but we're keeping it to try to duplicate MLZ's code exactly.
         if self.config.nrandom > 1:
-            if rank == 0:
+            if self._rank == 0:
                 print(f"creating {self.config.nrandom} random realizations...")
                 traindata.make_random(ntimes=int(self.config.nrandom))
                 temprandos = traindata.BigRan
             else:  # pragma: no cover
                 temprandos = None
-        if PLL == 'MPI': comm.Barrier()
+        if self._parallel == MPI_PARALLEL:
+            self._comm.Barrier()
 
         # Matias writes out randoms from make_random for rank=0, then reads them all back in from file so that all ranks have access,
         # that seems slow so, instead, let's just assign them here (after broadcasting to all):
-        temprandos = comm.bcast(temprandos, root=0)
+        temprandos = self._comm.bcast(temprandos, root=0)
         if self.config.nrandom > 1:
             traindata.BigRan = temprandos
-        if PLL == 'MPI': comm.Barrier()
+        if self._parallel == MPI_PARALLEL:
+            self._comm.Barrier()
 
         ntot = int(self.config.nrandom * self.config.ntrees)
-        if rank == 0:
+        if self._rank == 0:
             print(f"making a total of {ntot} trees for {self.config.nrandom} random realizations * {self.config.ntrees} bootstraps")
 
         zfine, zfine2, resz, resz2, wzin = analysis.get_zbins(self.config)
         zfine2 = zfine2[wzin]
 
-        s0, s1 = utils_mlz.get_limits(ntot, Nproc, rank)
-        if rank == 0:
+        # Add this assignment of Nproc to grab ceci's size param
+        Nproc = self._size
+        s0, s1 = utils_mlz.get_limits(ntot, Nproc, self._rank)
+        if self._rank == 0:
             for i in range(Nproc):
                 Xs_0, Xs_1 = utils_mlz.get_limits(ntot, Nproc, i)
                 if Xs_0 == Xs_1:  # pragma: no cover
@@ -215,7 +242,8 @@ class TPZliteInformer(CatInformer):
                     print(f"{Xs_0} - {Xs_1} -------------> to core {i}")
 
         treedict = {}
-        if PLL == 'MPI': comm.Barrier()
+        if self._parallel == MPI_PARALLEL:
+            self._comm.Barrier()
         # copy some stuff from the runMLZ script:
         for kss in range(s0, s1):
             print(f"making {kss+1} of {ntot}...")
@@ -241,25 +269,27 @@ class TPZliteInformer(CatInformer):
 
             treedict[f"tree_{kss}"] = T
 
-        if PLL == 'MPI':
-            if rank == 0:
-                for i in range(1, size, 1):
+        if self._parallel == MPI_PARALLEL:
+            if self._rank == 0:
+                for i in range(1, self._size, 1):
                     print(f"receiving data from rank {i}")
-                    xdata = comm.recv(source=i, tag=11)
+                    xdata = self._comm.recv(source=i, tag=11)
                     for key in xdata:
                         treedict[key] = xdata[key]
             else:
                 xdata = treedict.copy()
-                comm.send(xdata, dest=0, tag=11)
+                self._comm.send(xdata, dest=0, tag=11)
 
-        if PLL == 'MPI': comm.Barrier()
-        if rank == 0:
+        if self.parallel == MPI_PARALLEL:
+            self._comm.Barrier()
+        if self._rank == 0:
             self.model = dict(trainkeys=trainkeys,
                               treedict=treedict,
                               use_atts=self.config.use_atts,
                               zmin=self.config.zmin,
                               zmax=self.config.zmax,
                               nzbins=self.config.nzbins,
+                              redshift_col=self.config.redshift_col,
                               att_dict=train_att_dict,
                               keyatt=self.config.keyatt,
                               nrandom=self.config.nrandom,
@@ -288,7 +318,8 @@ class TPZliteEstimator(CatEstimator):
     """
     name = "TPZliteEstimator"
     config_options = CatEstimator.config_options.copy()
-    config_options.update(placeholder=Param(int, 9, msg="placeholder"),
+    config_options.update(nondetect_val=SHARED_PARAMS,
+                          mag_limits=SHARED_PARAMS,
                           test_err_dict=Param(dict, def_err_dict, msg="dictionary that contains the columns that will be used to \
                                          predict as the keys and the errors associated with that column as the values. \
                                          If a column does not havea an associated error its value shoule be `None`"))
@@ -309,6 +340,21 @@ class TPZliteEstimator(CatEstimator):
         """
 
         testkeys = list(inputdata.keys())
+
+        # replace non-detects with limiting mag and mag_err with 1.0
+        for bandname, errname in self.config.test_err_dict.items():
+            if bandname == self.attPars.redshift_col:
+                continue
+            if np.isnan(self.config.nondetect_val):  # pragma: no cover
+                magmask = np.isnan(inputdata[bandname])
+                errmask = np.isnan(inputdata[errname])
+            else:
+                magmask = np.isclose(inputdata[bandname], self.config.nondetect_val)
+                errmask = np.isclose(inputdata[errname], self.config.nondetect_val)
+
+            detmask = np.logical_or(magmask, errmask)
+            inputdata[bandname][detmask] = self.config.mag_limits[bandname]
+            inputdata[errname][detmask] = 1.0
 
         # make dictionary of attributes and error columns
         test_att_dict = make_index_dict(self.config.test_err_dict, testkeys)

--- a/src/rail/estimation/algos/tpz_lite.py
+++ b/src/rail/estimation/algos/tpz_lite.py
@@ -219,13 +219,19 @@ class TPZliteInformer(CatInformer):
                           dict_dim=DD)
 
             treedict[f"tree_{kss}"] = T
-            if PLL == 'MPI':
-                if rank == 0:
-                    treedat = comm.recv(source=i, tag=11)
-                    for key in treedat:
-                        treedict[key] = treedat[key]
-                else:
-                    comm.send(treedict, dest=0, tag=11)
+
+        if PLL == 'MPI':
+           if rank == 0:
+               for i in range(1, size, 1):
+                   print(f"receiving data from rank {i}")
+                   xdata = comm.recv(source=i, tag=11)
+                   for key in xdata:
+                       treedict[key] = xdata[key]
+           else:
+               xdata = treedict.copy()
+               comm.send(xdata, dest=0, tag=11)
+
+
 
         if PLL == 'MPI': comm.Barrier()
         if rank == 0:

--- a/src/rail/estimation/algos/tpz_lite.py
+++ b/src/rail/estimation/algos/tpz_lite.py
@@ -140,7 +140,8 @@ class TPZliteInformer(CatInformer):
         """compute the best fit prior parameters
         """
         rng = np.random.default_rng(seed=self.config.seed)
-        comm.Barrier()
+        if PLL == 'MPI':
+            comm.Barrier()
         if rank == 0:
             print(f"PLL IS {PLL}, number of processors we will use is {size}")
 
@@ -193,7 +194,8 @@ class TPZliteInformer(CatInformer):
 
         # Matias writes out randoms from make_random for rank=0, then reads them all back in from file so that all ranks have access,
         # that seems slow so, instead, let's just assign them here (after broadcasting to all):
-        temprandos = comm.bcast(temprandos, root=0)
+        if PLL == 'MPI':
+            temprandos = comm.bcast(temprandos, root=0)
         if self.config.nrandom > 1:
             traindata.BigRan = temprandos
         if PLL == 'MPI': comm.Barrier()

--- a/src/rail/estimation/algos/tpz_lite.py
+++ b/src/rail/estimation/algos/tpz_lite.py
@@ -30,14 +30,14 @@ try:
     from mpi4py import MPI
 
     PLL = 'MPI'
-except ImportError:
+except ImportError:  # pragma: no cover
     PLL = 'SERIAL'
 
 if PLL == 'MPI':
     comm = MPI.COMM_WORLD
     size = comm.Get_size()
     rank = comm.Get_rank()
-else:
+else:  # pragma: no cover
     size = 1
     rank = 0
 Nproc = size
@@ -150,7 +150,7 @@ class TPZliteInformer(CatInformer):
             training_data = self.get_data("input")
 
         valid_strategies = ["sklearn", "native"]
-        if self.config.tree_strategy not in valid_strategies:
+        if self.config.tree_strategy not in valid_strategies:  # pragma: no cover
             raise ValueError(f"value of {self.config.tree_strategy} not valid! Valid values for tree_strategy are 'native' or 'sklearn'")
         if self.config.tree_strategy == "sklearn" and rank == 0:
             print("using sklearn decision trees")
@@ -187,7 +187,7 @@ class TPZliteInformer(CatInformer):
                 print(f"creating {self.config.nrandom} random realizations...")
                 traindata.make_random(ntimes=int(self.config.nrandom))
                 temprandos = traindata.BigRan
-            else:
+            else:  # pragma: no cover
                 temprandos = None
         if PLL == 'MPI': comm.Barrier()
 
@@ -209,7 +209,7 @@ class TPZliteInformer(CatInformer):
         if rank == 0:
             for i in range(Nproc):
                 Xs_0, Xs_1 = utils_mlz.get_limits(ntot, Nproc, i)
-                if Xs_0 == Xs_1:
+                if Xs_0 == Xs_1:  # pragma: no cover
                     print(f"idle...  -------------> to core  {i}")
                 else:
                     print(f"{Xs_0} - {Xs_1} -------------> to core {i}")

--- a/src/rail/estimation/algos/tpz_lite.py
+++ b/src/rail/estimation/algos/tpz_lite.py
@@ -203,6 +203,7 @@ class TPZliteInformer(CatInformer):
                     print(f"{Xs_0} - {Xs_1} -------------> to core {i}")
 
         treedict = {}
+        if PLL == 'MPI': comm.Barrier()
         # copy some stuff from the runMLZ script:
         for kss in range(s0, s1):
             print(f"making {kss+1} of {ntot}...")
@@ -218,6 +219,12 @@ class TPZliteInformer(CatInformer):
                           dict_dim=DD)
 
             treedict[f"tree_{kss}"] = T
+            if rank == 0:
+                treedat = comm.recv(source=i, tag=11)
+                for key in treedat:
+                    treedict[key] = treedat[key]
+            else:
+                comm.send(treedict, dest=0, tag=11)
 
         if PLL == 'MPI': comm.Barrier()
         if rank == 0:

--- a/src/rail/estimation/algos/tpz_lite.py
+++ b/src/rail/estimation/algos/tpz_lite.py
@@ -219,12 +219,13 @@ class TPZliteInformer(CatInformer):
                           dict_dim=DD)
 
             treedict[f"tree_{kss}"] = T
-            if rank == 0:
-                treedat = comm.recv(source=i, tag=11)
-                for key in treedat:
-                    treedict[key] = treedat[key]
-            else:
-                comm.send(treedict, dest=0, tag=11)
+            if PLL == 'MPI':
+                if rank == 0:
+                    treedat = comm.recv(source=i, tag=11)
+                    for key in treedat:
+                        treedict[key] = treedat[key]
+                else:
+                    comm.send(treedict, dest=0, tag=11)
 
         if PLL == 'MPI': comm.Barrier()
         if rank == 0:

--- a/tests/test_tpz.py
+++ b/tests/test_tpz.py
@@ -1,5 +1,6 @@
 import numpy as np
 import os
+import pytest
 from rail.core.stage import RailStage
 from rail.core.algo_utils import one_algo
 from rail.core.data import TableHandle
@@ -7,10 +8,13 @@ from rail.core.utils import RAILDIR
 from rail.core.utils import find_rail_file
 from rail.estimation.algos.tpz_lite import TPZliteInformer, TPZliteEstimator
 
-
-def test_tpz_larger_training():
-    train_config_dict = {"hdf5_groupname": "photometry", "nrandom": 2, "ntrees": 2,
-                         "model": "tpz_tests.pkl"}
+@pytest.mark.parametrize(
+    "treestrat",
+    ["native", "sklearn"]
+)
+def test_tpz_larger_training(treestrat):
+    train_config_dict = {"hdf5_groupname": "photometry", "nrandom": 2, "ntrees": 5,
+                         "model": "tpz_tests.pkl", "tree_strategy": treestrat}
     estim_config_dict = {"hdf5_groupname": "photometry", "model": "tpz_tests.pkl"}
     train_algo = TPZliteInformer
     pz_algo = TPZliteEstimator


### PR DESCRIPTION
This PR addresses two issues: #7 to add mpi4py parallelization to the inform stage to speed things up, and #11 to add a config option that lets the user use sklearn's `DecisionTreeRegressor` rather than the custom tree code included with TPZ.  Training with sklearn trees is 1000-10000x as fast (1 min 9 seconds vs 50.2 hours on my home mac for a large training file), estimation seems to be 2-5x faster with sklearn.  

Test coverage is at 100% when run with mpirun, though a couple tests fail, though tests pass with single processor (but a few lines of code run in parallel mode are not executed), so I may need help figuring out how to get that to work properly with GitHub actions, otherwise everything looks good.