### PR TITLE
add if statement before Bcast

### DIFF
--- a/src/rail/estimation/algos/tpz_lite.py
+++ b/src/rail/estimation/algos/tpz_lite.py
@@ -219,7 +219,8 @@ class TPZliteInformer(CatInformer):
         # Matias writes out randoms from make_random for rank=0, then reads them all back in from file so that all ranks have access,
         # that seems slow so, instead, let's just assign them here (after broadcasting to all):
         if self._parallel == MPI_PARALLEL:
-            temprandos = self._comm.bcast(temprandos, root=0)
+            if self.config.nrandom > 1:
+                temprandos = self._comm.bcast(temprandos, root=0)
         if self.config.nrandom > 1:
             traindata.BigRan = temprandos
         if self._parallel == MPI_PARALLEL:

--- a/tests/test_tpz.py
+++ b/tests/test_tpz.py
@@ -9,11 +9,12 @@ from rail.core.utils import find_rail_file
 from rail.estimation.algos.tpz_lite import TPZliteInformer, TPZliteEstimator
 
 @pytest.mark.parametrize(
-    "treestrat",
-    ["native", "sklearn"]
+    "treestrat, nrand",
+    [("native", 2),
+     ("sklearn", 1)]
 )
-def test_tpz_larger_training(treestrat):
-    train_config_dict = {"hdf5_groupname": "photometry", "nrandom": 2, "ntrees": 5,
+def test_tpz_larger_training(treestrat, nrand):
+    train_config_dict = {"hdf5_groupname": "photometry", "nrandom": nrand, "ntrees": 5,
                          "model": "tpz_tests.pkl", "tree_strategy": treestrat}
     estim_config_dict = {"hdf5_groupname": "photometry", "model": "tpz_tests.pkl"}
     train_algo = TPZliteInformer


### PR DESCRIPTION
This PR adds a single if statement to cover the nrandom=1 case, and fixes a bug where if nrandom was set to 1 random data was not created, but then the code attempted to comm.Bcast() this nonexistent data.  Added the if statement to only broadcast if nrandom>1.