### PR TITLE
fix RAILDIR and one_algo paths

### DIFF
--- a/examples/TPZ_example_notebook.ipynb
+++ b/examples/TPZ_example_notebook.ipynb
@@ -8,7 +8,7 @@
     "# TPZ: Trees for Photo-Z's\n",
     "\n",
     "Author: Sam Schmidt <br>\n",
-    "Last successfully run: Oct 6, 2023 <br>\n",
+    "Last successfully run: May 10, 2024 <br>\n",
     "\n",
     "TPZ is one of the codes implemented in the MLZ (Machine Learning PhotoZ) package by Matias Carraso-Kind, some documentation for the algorithm is included in Matias' website for the package:\n",
     "http://matias-ck.com/mlz/\n",
@@ -56,7 +56,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from rail.core.utils import RAILDIR"
+    "from rail.utils.path_utils import RAILDIR"
    ]
   },
   {
@@ -413,7 +413,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.10.13"
   }
  },
  "nbformat": 4,

--- a/tests/test_tpz.py
+++ b/tests/test_tpz.py
@@ -5,7 +5,7 @@ from rail.core.stage import RailStage
 from rail.utils.testing_utils import one_algo
 from rail.core.data import TableHandle
 from rail.utils.path_utils import RAILDIR
-from rail.core.utils import find_rail_file
+from rail.utils.path_utils import find_rail_file
 from rail.estimation.algos.tpz_lite import TPZliteInformer, TPZliteEstimator
 
 @pytest.mark.parametrize(

--- a/tests/test_tpz.py
+++ b/tests/test_tpz.py
@@ -2,9 +2,9 @@ import numpy as np
 import os
 import pytest
 from rail.core.stage import RailStage
-from rail.core.algo_utils import one_algo
+from rail.utils.testing_utils import one_algo
 from rail.core.data import TableHandle
-from rail.core.utils import RAILDIR
+from rail.utils.path_utils import RAILDIR
 from rail.core.utils import find_rail_file
 from rail.estimation.algos.tpz_lite import TPZliteInformer, TPZliteEstimator
 


### PR DESCRIPTION
Quick PR that fixes breaking of tests build and updates path to RAILDIR in the example notebook that were caused by the big renaming earlier this week.  Should be fairly self-explanatory,  tests now pass and notebook runs as expected with the updates.