### PR TITLE
fix conflict that got commited in last PR

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -34,9 +34,4 @@ jobs:
     - name: Build package
       run: python -m build
     - name: Publish package
-<<<<<<< before updating
       uses: pypa/gh-action-pypi-publish@release/v1
-
-=======
-      uses: pypa/gh-action-pypi-publish@release/v1
->>>>>>> after updating


### PR DESCRIPTION
removes a conflict from publish-to-pypi that accidentally slipped through in the last PR.