### PR TITLE
Issue/29/columns addresses #29

### DIFF
--- a/examples/TPZ_example_notebook.ipynb
+++ b/examples/TPZ_example_notebook.ipynb
@@ -8,7 +8,7 @@
     "# TPZ: Trees for Photo-Z's\n",
     "\n",
     "Author: Sam Schmidt <br>\n",
-    "Last successfully run: May 10, 2024 <br>\n",
+    "Last successfully run: March 24, 2025 <br>\n",
     "\n",
     "TPZ is one of the codes implemented in the MLZ (Machine Learning PhotoZ) package by Matias Carraso-Kind, some documentation for the algorithm is included in Matias' website for the package:\n",
     "http://matias-ck.com/mlz/\n",
@@ -19,7 +19,7 @@
     "\n",
     "Initially, we have only implemented the regression-tree versionof the code, though the classification-tree method may be re-implemented at a future time.  Furthermore, the original code had options for out-of-bag (oob) error estimates and variational importance sampling, those have not been included initially, but will hopefully be added as options in the near future.\n",
     "\n",
-    "For a quick summary of how the code operates, given a set of galaxy observables (usually magnitudes, and optional uncertainties), TPZ builds a set of decision trees where it splits a training set by some of the included parameters in a way that best differentiates the parameter of interest (in our case redshift).  It then repeating splits on parameters in each leaf branch of each tree that best split the remaining data, thus building up a decision tree.  It creates multiple trees in two ways: 1) by creating N bootstrap realizations of the initial training set; 2) if uncertainties are provided (e.g. magnitude uncertainties) it creates M alternative training set realizations by adding Gaussian scatter to the training quantities galaxy-by-galaxy (Note: if an error is not supplied it assumes a very small error of 0.00005 for the Gaussian sigma).  Thus, it trains up a total of N x M total trees for its model, e.g. if you tell TPZ that you want 5 random realizations and 4 trees it will create 5 random datasets and bootstrap those 4 times to train a total of 20 trees.  \n",
+    "For a quick summary of how the code operates, given a set of galaxy observables (usually magnitudes, and optional uncertainties), TPZ builds a set of decision trees where it splits a training set by some of the included parameters in a way that best differentiates the parameter of interest (in our case redshift).  It then performs repeated splits on parameters in each leaf branch of each tree that best differentiate the remaining data, thus building up a decision tree.  It creates multiple trees in two ways: 1) by creating N bootstrap realizations of the initial training set; 2) if uncertainties are provided (e.g. magnitude uncertainties) it creates M alternative training set realizations by adding Gaussian scatter to the training quantities galaxy-by-galaxy (Note: if an error is not supplied it assumes a very small error of 0.00005 for the Gaussian sigma).  Thus, it trains up a total of N x M total trees for its model, e.g. if you tell TPZ that you want 5 random realizations and 4 trees it will create 5 random datasets and bootstrap those 4 times to train a total of 20 trees.  \n",
     "To create a photo-z estimate, it then lets each test galaxy plinko down through the decision tree, and adds the redshifts of the training galaxies in the terminal leaf node to a histogram, building up the final PDF by looking at all N x M trees.\n",
     "\n",
     "## Running TPZ\n",
@@ -127,18 +127,28 @@
    "metadata": {},
    "source": [
     "Next, we will create a dictionary with the configuration parameters that controld TPZ's behavior that we will feed to the `make_stage` method of `TPZliteInformer` to set up our training of the trees.  There are several configuration parameters available for TPZliteInformer.  A number of these are \"shared parameters\", including:\n",
-    "`zmin`, `zmax`, `nzbins`, `mag_limits`, `bands`, `err_bands`, `redshift_col`.\n",
+    "`zmin`, `zmax`, `nzbins`, `mag_limits`, and `redshift_col`.\n",
+    "\n",
+    "Two shared parameter play an imporant role in TPZ:<br>\n",
+    "- `bands` is a list that contains the names of the columns that will be used as features in the tree.  While we use the name `bands` to be consistent with other parts of RAIL, note that other meaningful quantities, e.g. size, shape, concentration, surface brightness, etc..., could also be used.\n",
+    "-  `err_bands` contains a list of the column names that contain the 1-sigma uncertainties for the quantities listed in `bands`.  As TPZ creates mock data by sampling from the uncertainty distributions when making its forest of trees, these quantities are necessary for proper functioning of the code.\n",
+    "\n",
+    "Additionally, the configuration parameter `err_dict` must be a dictionary that contains the columns that will be used to predict as the keys and the errors associated with that column as the values, e.g. `errdict[\"mag_u_lsst\"] = \"mag_err_u_lsst\"`.  This dictionary is used by the code that generates random realizations of the galaxy by adding Gaussian scatter, it tells that bit of code which columns contain errors for each of the attributes that will have Gaussian scatter added. <br>\n",
+    "\n",
     "The other configuration parameters for TPZ are:\n",
     "- `seed` (int): the random seed used by numpy for this stage <br>\n",
-    "- `use_atts` (list): a list of the attributes (i.e. column names from the hdf5 files) that you want TPZ to use as the attributes of the decision tree. <br>\n",
-    "- `err_dict` (dictionary): a dictionary that contains the columns that will be used to predict as the keys and the errors associated with that column as the values, e.g. `errdict[\"mag_u_lsst\"] = \"mag_err_u_lsst\"`.  This dictionary is used by the code that generates random realizations of the galaxy by adding Gaussian scatter, it tells that bit of code which columns contain errors for each of the attributes that will have Gaussian scatter added. <br>\n",
     "- `nrandom` (int): the number of random training catalogs with Gaussian scatter to create. <br>\n",
     "- `ntrees` (int): the number of bootstrap samples for a given random catalog to create. <br>\n",
     "REMINDER: the total number of trees trained will be `nrandom` * `ntrees`, and if `nrandom` is set to 1, then no random catalogs are created, only the original training sample is used.<br>\n",
     "- `minleaf` (int): the mininum number of galaxies in a terminal leaf. <br>\n",
     "- `natt` (int): the number of attributes to split. <br>\n",
     "- `sigmafactor` (float): Gaussian smoothing with kernel Sigma1*Resolution. <br>\n",
-    "- `rmsfactor` (float): MS for zconf calculation. <br>"
+    "- `rmsfactor` (float): MS for zconf calculation. <br>\n",
+    "- `tree_strategy` (string): see paragraph below.<br>\n",
+    "\n",
+    "`rail_tpz` uses a parameter, `tree_strategy` that which specific algorithm is used to construct the trees, and this choice can have a few important effects on the results.  The original TPZ code contains bespoke decision tree code custom written for the algorighm to perform the recursive data splits.  While it is functional, it can be somewhat slow.  As an alternative, we have implemented an alternative method that instead uses scikit-learn's `DecisionTreeRegressor`, which can result in training times for the random forest informer of more than 10,000 times faster than native.  The specifics for how the decisionas to where tree splits occur are slightly different between the \"native\" and \"sklearn\" methods, though resulting photo-z predictions are qualitatively similar.\n",
+    "\n",
+    "There is a notable difference in how the two methods handle the PDF construction that will affect results: both methods look at the input galaxy and use the decision tree to find the galaxies that are most similar to that input galaxy, splitting in the tree until they reach the \"terminal leaf\" where the last split occurs.  There are a small number of galaxies in this terminal leaf.  the \"native\" method takes this small number of galaxies and makes a histogram of their redshifts, and combines the MxN tree histograms to construct the final PDF.  The \"sklearn\" method, on the other hand, takes the mean of the small number of galaxies in the terminal leaf and returns a single float, so the final PDF estimate will be a histogram of single values from each of the MxN trees rather than #in leaf node xN xM entries for the \"native\" representation.  While results should mostly be qualitatively similar, the fact that TPZ uses bootstrap sampling when constructing the different trees means that some specz values can be repeated in some trees if they are drawn multiple times in the bootstrap.  In areas of photometric space with sparse coverage of spectroscopic galaxies, this can result in discrete values appearing multiple times in the histogram of neighbors in the PDF.  This can manifest as repeated values of the mode, for example, often seen at high redshift.  The \"sklearn\" strategy of averaging over the terminal leaf can somewhat mitigate this effect, as the discrete values are slightly smoothed by the averaging over the terminal leaf sample.   If you re-run this example notebook and switch the `tree_strategy` from \"sklearn\" to \"native\", you will likely see some discrete mode values in either a histogram of the zmode or plot of mode vs true redshift.  One method is not generally better than the other, it is simply a feature that users should be aware of, as it can impact a specific science case, particularly if point estimate are going to be employed.\n"
    ]
   },
   {
@@ -146,9 +156,9 @@
    "id": "dfa1c5b1-d009-405e-b68d-a6b139513d96",
    "metadata": {},
    "source": [
-    "We need to specify the attributes that TPZ will use to create its trees, we do this via a list passed to the `use_atts` configuration parameter.  While the default list would work, we'll create and use it explicitly in this example.  Redshift, the parameter that we are trying to predict, should not be included in the attribute list (but needs to be included in the data file so the trees can be trained to split on it).\n",
+    "We need to specify the attributes that TPZ will use to create its trees, we do this via a list passed to the `bands` parameter.  While the default list would work, we'll create and use it explicitly in this example.  Redshift, the parameter that we are trying to predict, should not be included in the attribute list (but needs to be included in the data file so the trees can be trained to split on it).\n",
     "\n",
-    "TPZ generates addtional \"random\" realizations of a training set by adding Gaussian scatter in attributes with sigma values taken from a different column in the input file.  The corresponding uncertainty columns for each attribute are stored as a dictionary with the name of the attribute column as the key and the name of the uncertainty as the value, this configuration parameter is `err_dict`.  While the default values set by `tpz_lite` would work, we'll create the necessary dictionary explicity and use it for illustration:"
+    "TPZ generates addtional \"random\" realizations of a training set by adding Gaussian scatter in attributes with sigma values taken from a different column in the input file.  The corresponding uncertainty columns for each attribute are stored as a dictionary with the name of the attribute column as the key and the name of the uncertainty as the value, this configuration parameter is `err_dict`.  While the default values set by `tpz_lite` would work, we'll create the necessary dictionary explicity and use it for illustration.  As mentioned above, using \"sklearn\" for the `tree_strategy` is much faster, so we will use that option in this demo."
    ]
   },
   {
@@ -161,8 +171,10 @@
     "bands = [\"u\", \"g\", \"r\", \"i\", \"z\", \"y\"]\n",
     "new_err_dict = {}\n",
     "attribute_list = []\n",
+    "error_list = []\n",
     "for band in bands:\n",
     "    attribute_list.append(f\"mag_{band}_lsst\")\n",
+    "    error_list.append(f\"mag_err_{band}_lsst\")\n",
     "    new_err_dict[f\"mag_{band}_lsst\"] = f\"mag_err_{band}_lsst\"\n",
     "# redshift is also an attribute used in the training, but it does not have an associated\n",
     "# error its entry in the err_dict should be set to \"None\"\n",
@@ -180,12 +192,15 @@
    "source": [
     "tpz_dict = dict(zmin=0.0, \n",
     "                zmax=3.0, \n",
-    "                nzbins=301, \n",
+    "                nzbins=301,\n",
+    "                bands=attribute_list,\n",
+    "                err_bands=error_list,\n",
     "                hdf5_groupname='photometry',\n",
-    "                use_atts=attribute_list,\n",
     "                err_dict=new_err_dict,\n",
     "                nrandom=3, \n",
-    "                ntrees=5)"
+    "                ntrees=5,\n",
+    "                #tree_strategy='native')  # uncomment this line and comment out the line below to switch to using \"native\" trees \n",
+    "                tree_strategy='sklearn')"
    ]
   },
   {
@@ -193,7 +208,7 @@
    "id": "638f6f40-e60d-47f4-b639-6bb4560b1631",
    "metadata": {},
    "source": [
-    "Now, lets create our stage and run `inform`.  We specified `nrandom = 3` and `ntrees = 5`, so we will get 15 trained trees that constitute our model.  For our 10k training galaxy sample this takes about 90 seconds to run on my Mac desktop for a rough guide for how long this should take to train:"
+    "Now, lets create our stage and run `inform`.  We specified `nrandom = 3` and `ntrees = 5`, so we will get 15 trained trees that constitute our model.  For our 10k training galaxy sample this takes about 0.5 seconds for \"sklearn\", or about 90 seconds using \"native\" on my Mac desktop for a rough guide for how long this should take to train:"
    ]
   },
   {
@@ -372,7 +387,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "which=1355\n",
+    "which=5355\n",
     "fig, axs = plt.subplots()\n",
     "results().plot_native(key=which,axes=axs, label=f\"PDF for galaxy {which}\")\n",
     "axs.axvline(sz[which],c='r',ls='--', label=\"true redshift\")\n",


### PR DESCRIPTION
This PR addresses #29, eliminating the `use_atts` config parameter, and only copies the columns needed to numpy, which should reduce memory usage a bit.